### PR TITLE
[#138] open alert box when funds in old wallet

### DIFF
--- a/src/js/pages.init.js
+++ b/src/js/pages.init.js
@@ -129,6 +129,21 @@ function initBalances() {
       } else {
           WALLET.refreshBTCBalances(false);
       }
+
+      WALLET.BITCOIN_WALLET.getOldAddressesInfos(function(data) {   
+        var needSweep = false;
+        for (var a in data) {
+          needSweep = true;
+          break;
+        }
+        if (needSweep) {
+          bootbox.confirm("<b style='color:red'>We detected that you have used a previous wallet. press 'OK' to sweep into this new one.</b>", function(value) {
+            if (value) {
+              SWEEP_MODAL.show(true, true);
+            }
+          });
+        }
+      });
   });
 }
 INIT_FUNC['pages/balances.html'] = initBalances;


### PR DESCRIPTION
When connecting in the new wallet, we detect if funds are in the old wallet. If yes, an alert box display this message: "We detected that you have used a previous wallet. press 'OK' to sweep into this new one."
