### PR TITLE
Fix #576 - element width doesn't respect localized string length

### DIFF
--- a/src/css/components/logon.css
+++ b/src/css/components/logon.css
@@ -15,7 +15,7 @@
 }
 
 #form-well {
-    max-width: 610px;
+    max-width: 650px;
     margin: 0 auto;
     padding-bottom: 0px;
 }
@@ -37,11 +37,11 @@
 }
 
 #form-well .btn-success {
-  width: 250px;
+  min-width: 250px;
 }
 
 #walletLoginButton {
-  width: 70%;
+  min-width: 70%;
 }
 
 #secureKeyboardButton {

--- a/src/css/misc.css
+++ b/src/css/misc.css
@@ -80,7 +80,9 @@ span.modeIndicator {
   color: red;
   background-color: white;
   display: block;
-  width: 230px;
+  min-width: 216px;
+  padding-left: 7px;
+  padding-right: 7px;
   position: absolute;
   left: 50%;
   margin-left: -115px;
@@ -91,7 +93,7 @@ span.modeIndicator {
 @media only screen and (max-width : 860px) {
   #noticeTestnet {
     font-size:13px;
-    width: 116px;
+    min-width: 116px;
     margin-left: -58px;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -377,7 +377,7 @@
                   <input id="passwordDecrypt" data-bind="value: passwordDecrypt, valueUpdate: 'input', localeAttr: {'placeholder': 'enter_quick_password'}" class="form-control" type="password" name="passwordDecrypt">
                 </div>
 
-                <div class="col-sm-4">
+                <div class="col-sm-4" style="white-space:nowrap">
                   <button id="walletLoginButton" data-bind="click: openWallet, enable: isPassphraseValid(), css: { 'btn-primary': isPassphraseValid() }, locale: 'open_wallet'" type="button" class="btn btn-default" disabled></button>
                   &nbsp;<button id="secureKeyboardButton" data-bind="click: showSecureKeyboard, enable: !isPassphraseValid(), css: { 'btn-primary': !isPassphraseValid() }" type="button" class="btn btn-default" disabled><i class="fa fa-keyboard-o"></i></button>
                   <div class="showSupport"><a href="#" data-bind="locale: 'login_problems'"></a></div>


### PR DESCRIPTION
This fixes all three cases where HTML elements can't deal with slightly longer string that I discovered in Czech localization. Two of them don't require any changes to English layout, but to make the third one, "walletLoginButton" adjustable, I had to increase max-width of the parent element a little bit.
