### PR TITLE
Fix #600 - broken labels in Betting and Exchange

### DIFF
--- a/src/pages/betting.html
+++ b/src/pages/betting.html
@@ -245,25 +245,25 @@
                           <thead></thead>
                           <tbody>
                             <tr data-bind="visible: $parent.jsonBetProvided">
-                              <td><b><span data-blind="locale: 'operator'"></span>:</b></td>
+                              <td><b><span data-bind="locale: 'operator'"></span>:</b></td>
                               <td>
                                 <a data-bind="attr: {href: info_data.operator.url}" target="_blank"><span data-bind="text: info_data.operator.name"></span></a>
                               </td>
                             </tr>
                             <tr>
-                              <td><b><span data-blind="locale: 'wager'"></span>:</b></td>
+                              <td><b><span data-bind="locale: 'wager'"></span>:</b></td>
                               <td><b><span data-bind="text: $parent.wager + ' XCP'"></span></b></td>
                             </tr>
                             <tr data-bind="visible: info_data.type=='binary'">          
-                              <td><b><span data-blind="locale: 'topic'"></span>:</b></td>
+                              <td><b><span data-bind="locale: 'topic'"></span>:</b></td>
                               <td><b><span data-bind="text: $parent.targetValueText"></span></b></td>  
                             </tr>
                             <tr>          
-                              <td><b><span data-blind="locale: 'your_choice'"></span>:</b></td>
+                              <td><b><span data-bind="locale: 'your_choice'"></span>:</b></td>
                               <td><b><span data-bind="text: $parent.betTypeText"></span></b></td> 
                             </tr>
                             <tr>
-                              <td><b><span data-blind="locale: 'odds'"></span>:</b></td>
+                              <td><b><span data-bind="locale: 'odds'"></span>:</b></td>
                               <td>
                                 <div class="progress progress-sm odd-bar">
                                   <div class="progress-bar bg-color-greenLight" data-bind="attr: {style: 'width: '+$parent.greenPercent()+'%'}"></div>

--- a/src/pages/exchange.html
+++ b/src/pages/exchange.html
@@ -78,7 +78,7 @@
                 <div class="row" style="height:90px">
                     <section class="col col-lg-4 col-sm-4">
                       <div style="padding:10px">
-                        <label for="asset1" class="control-label font-medlg" data-blind="locale: 'token_1'"></label>
+                        <label for="asset1" class="control-label font-medlg" data-bind="locale: 'token_1'"></label>
                         <label class="input" style="margin-bottom:0">
                             <input type="text" id="asset1" name="asset1" class="form-control input" type="text" placeholder="Asset name" data-bind="value: asset1" />
                         </label>
@@ -87,7 +87,7 @@
                     </section>
                     <section class="col-md-3">
                       <div style="padding-top:10px">
-                        <label for="asset2" class="control-label font-medlg"  data-blind="locale: 'token_2'"></label>
+                        <label for="asset2" class="control-label font-medlg"  data-bind="locale: 'token_2'"></label>
                         <div class="btn-group buySellBtnGroup" data-toggle="buttons" style="margin-bottom:0">
                           <label class="radioBtn btn" data-bind="css: { 'btn-success': selectedQuoteAsset() == 'XCP', 'active': selectedQuoteAsset() == 'XCP'}">
                             <input type="radio" value="XCP" data-bind="btnGroupChecked: selectedQuoteAsset">XCP</label>


### PR DESCRIPTION
I checked the file history, the bug was introduced in September, when @phillipsio accidentally typed data-blind instead of data-bind in commits 52a0d330245eba2c69d23e81c2b502edb29d399c and 68dd79e7e660223e1d3624889205dca6af288ae2

Fixes issue #600.
