### PR TITLE
fixed renamed bower dependancy link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v1.6.2 ###
+### v1.6.3 ###
 **Enhancements:**
 - Allow `OP_RETURN`; use`'auto'` encoding
 
@@ -8,6 +8,14 @@
 **Fixes:**
 - Fix `refreshCounterpartyBalances()`
 - Fix pending message for issuance with quantity=0
+
+### v1.6.2 ###
+**Fixes:**
+- Proper formatting for multisig addresses on history page and stats page
+- Updated terminology in several parts of the UI
+- Updated blockscan links in the history page and stats page
+- Blockscan links now work with testnet
+- A few other minor changes
 
 ### v1.6.1 ###
 **Fixes:**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Slack Status](http://slack.counterparty.io/badge.svg)](http://slack.counterparty.io)
+
 Counterwallet
 ================
 

--- a/src/bower.json
+++ b/src/bower.json
@@ -19,7 +19,7 @@
         "jqlog": "https://jqlog.googlecode.com/files/jqlog-1.3.zip",
         "keyboard": "1.18.8",
         "jReject": "1.0.2",
-        "jReject-ie11": "https://raw.githubusercontent.com/AppRiver/jReject/39e310ffb8659488f3d376b721b3a54c89a19d68/js/jquery.reject.js",
+        "jReject-ie11": "https://raw.githubusercontent.com/TurnWheel/jReject/39e310ffb8659488f3d376b721b3a54c89a19d68/js/jquery.reject.js",
         "jquery.slimscroll": "1.3.1",
         "jquery-timeago": "1.4.0",
         "jquery-yql": "https://raw.githubusercontent.com/hail2u/jquery.query-yql/655264551b7962485bcf0d06226e053a6f24629b/jquery.query-yql.js",

--- a/src/js/components/wallet.js
+++ b/src/js/components/wallet.js
@@ -579,17 +579,6 @@ function WalletViewModel() {
     assert(['sign_tx', 'broadcast_tx', 'convert_armory_signedtx_to_raw_hex'].indexOf(action) === -1,
       'Specified action not supported through this function. please use appropriate primatives');
 
-    if(action == 'create_cancel') {
-      if (self.cancelOrders.indexOf(data['offer_hash']) != -1) {
-        $.jqlog.debug(data['offer_hash'] + ' already cancelled.')
-        return;
-      } else {
-        $('#btcancel_' + data['offer_hash']).addClass('disabled');
-        self.cancelOrders.push(data['offer_hash']);
-        localStorage.setObject("cancelOrders", self.cancelOrders);
-      }
-    }
-    
     var addressObj = WALLET.getAddressObj(address);
     
     //should not ever be a watch only wallet
@@ -680,6 +669,17 @@ function WalletViewModel() {
               data['_divisible'] = extra1;
             }
             PENDING_ACTION_FEED.add(txHash, category, data);
+
+            if(action == 'create_cancel') {
+              if (self.cancelOrders.indexOf(data['offer_hash']) != -1) {
+                $.jqlog.debug(data['offer_hash'] + ' already cancelled.')
+                return;
+              } else {
+                $('#btcancel_' + data['offer_hash']).addClass('disabled');
+                self.cancelOrders.push(data['offer_hash']);
+                localStorage.setObject("cancelOrders", self.cancelOrders);
+              }
+            }
             
             return onSuccess ? onSuccess(txHash, data, endpoint, 'normal', null) : null;
           }, onError, verifyDestAddr);

--- a/src/js/components/wallet.js
+++ b/src/js/components/wallet.js
@@ -579,6 +579,15 @@ function WalletViewModel() {
     assert(['sign_tx', 'broadcast_tx', 'convert_armory_signedtx_to_raw_hex'].indexOf(action) === -1,
       'Specified action not supported through this function. please use appropriate primatives');
 
+    if (action == 'create_cancel') {
+      if (self.cancelOrders.indexOf(data['offer_hash']) != -1) {
+        $.jqlog.debug(data['offer_hash'] + ' already cancelled.')
+        return;
+      } else {
+        $('#btcancel_' + data['offer_hash']).addClass('disabled');
+      }
+    }
+
     var addressObj = WALLET.getAddressObj(address);
     
     //should not ever be a watch only wallet
@@ -642,6 +651,7 @@ function WalletViewModel() {
           
         //if the address is an armory wallet, then generate an offline transaction to get signed
         if(addressObj.IS_ARMORY_OFFLINE) {
+
           multiAPIConsensus("create_armory_utx", {'unsigned_tx_hex': unsignedTxHex, 'public_key_hex': addressObj.PUBKEY},
             function(asciiUTx, numTotalEndpoints, numConsensusEndpoints) {
               //DO not add to pending action feed (it will be added automatically via zeroconf when the p2p network sees the tx)
@@ -649,12 +659,21 @@ function WalletViewModel() {
               return onSuccess ? onSuccess(null, data, null, 'armory', asciiUTx) : null;
             }
           );
+          if (action == 'create_cancel') {
+            $('#btcancel_' + data['offer_hash']).removeClass('disabled');
+          }
           return;
+
         } else if (addressObj.IS_MULTISIG_ADDRESS) {
 
           self.showTransactionCompleteDialog("<b>"+ i18n.t('mutisig_tx_read') +"</b>", null, null, unsignedTxHex);
+          if (action == 'create_cancel') {
+            $('#btcancel_' + data['offer_hash']).removeClass('disabled');
+          }
+          return;
 
         } else {
+
           WALLET.signAndBroadcastTx(address, unsignedTxHex, function(txHash, endpoint) {
             //register this as a pending transaction
             var category = action.replace('create_', '') + 's'; //hack
@@ -670,20 +689,21 @@ function WalletViewModel() {
             }
             PENDING_ACTION_FEED.add(txHash, category, data);
 
-            if(action == 'create_cancel') {
-              if (self.cancelOrders.indexOf(data['offer_hash']) != -1) {
-                $.jqlog.debug(data['offer_hash'] + ' already cancelled.')
-                return;
-              } else {
-                $('#btcancel_' + data['offer_hash']).addClass('disabled');
-                self.cancelOrders.push(data['offer_hash']);
-                localStorage.setObject("cancelOrders", self.cancelOrders);
-              }
+            if (action == 'create_cancel') {
+              $('#btcancel_' + data['offer_hash']).addClass('disabled');
+              self.cancelOrders.push(data['offer_hash']);
+              localStorage.setObject("cancelOrders", self.cancelOrders);
             }
             
             return onSuccess ? onSuccess(txHash, data, endpoint, 'normal', null) : null;
-          }, onError, verifyDestAddr);
+          }, function(jqXHR, textStatus, errorThrown) { 
+            if (action == 'create_cancel') {
+              $('#btcancel_' + data['offer_hash']).removeClass('disabled');
+            }
+            onError(jqXHR, textStatus, errorThrown);
+          }, verifyDestAddr);
         }
+
     });
   }
   


### PR DESCRIPTION
fixed dependancy, seems AppRiver renamed their account to TurnWheel.

tbh I'd personally fork all the repos that I use in this way (a github link to a specific commit) to CounterpartyXCP and reference them there instead.