### PR TITLE
Updated some support-related URLs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -605,18 +605,18 @@
             <div data-bind="visible: type == 'balancesPage'">
                 <h5 data-bind="locale: 'answers_to_common_questions'"></h5>
                 <ul>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003512-i-logged-in-and-my-address-is-different-and-i-have-no-balance-" target="_blank" data-bind="locale: 'answer_1'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003515-i-sent-funds-to-a-crowdsale-vending-machine-why-don-t-they" target="_blank" data-bind="locale: 'answer_2'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003518-i-sent-btc-to-counterwallet-why-doesn-t-it-show" target="_blank" data-bind="locale: 'answer_3'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/i-logged-in-and-my-address-is-different-and-i-have-no-balance-help/1684" target="_blank" data-bind="locale: 'answer_1'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/how-do-i-participate-in-crowdfunding-of-projects-issued-on-counterparty/1153" target="_blank" data-bind="locale: 'answer_2'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/i-sent-btc-xcp-token-a-while-ago-but-the-transaction-hasnt-gone-through-why/1854" target="_blank" data-bind="locale: 'answer_3'"></a></li>
                     <br/>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003514-why-do-i-need-small-amounts-of-bitcoin-to-do" target="_blank" data-bind="locale: 'answer_4'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003519-address-i-added-in-counterwallet-is-not-showing-" target="_blank" data-bind="locale: 'answer_5'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003520-does-counterwallet-support-two-factor" target="_blank" data-bind="locale: 'answer_6'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003516-how-do-i-get-support-for-counterwallet" target="_blank" data-bind="locale: 'answer_8'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/why-do-i-need-small-amounts-of-bitcoin-to-do-things/1142/1" target="_blank" data-bind="locale: 'answer_4'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/my-address-in-counterwallet-disappeared/1222" target="_blank" data-bind="locale: 'answer_5'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/does-counterwallet-have-two-factor-authentication-2fa/2071" target="_blank" data-bind="locale: 'answer_6'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/about-the-counterwallet-support-category/29" target="_blank" data-bind="locale: 'answer_8'"></a></li>
                 </ul>
                 <h5 class="margin-bottom-0">
                   <span data-bind="locale: 'for_other_questions'"></span> 
-                  <a href="https://forums.counterparty.io/c/support" target="_blank" data-bind="locale: 'counterparty_forums'"></a>.
+                  <a href="https://counterpartytalk.org/c/support" target="_blank" data-bind="locale: 'counterparty_forums'"></a>.
                 </h5>
                 <h5>
                   <span data-bind="locale: 'for_bugs'"></span>
@@ -626,16 +626,16 @@
             <div data-bind="visible: type == 'exchangePage'">
                 <h5 data-bind="locale: 'answers_to_common_questions'"></h5>
                 <ul>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003522-what-does-something-like-xcp-btc-mean-in" target="_blank" data-bind="locale: 'answer_9'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003513-i-placed-an-order-to-buy-btc-for-something-else-what-i-offered-was-removed-from-my-account-but-i" target="_blank" data-bind="locale: 'answer_11'"></a></li>
-                    <li><a href="https://support.counterparty.io/support/solutions/articles/5000003514-why-do-i-need-small-amounts-of-bitcoin-to-do" target="_blank" data-bind="locale: 'answer_12'"></a></li>
-                    <li><a href="http://support.counterparty.io/support/solutions/articles/5000049906-what-is-the-difference-between-miner-s-fee-and-redeemable" target="_blank" data-bind="locale: 'answer_13'"></a></li>
-                    <li><a href="http://support.counterparty.io/support/solutions/articles/5000051505-what-btc-sellers-on-the-counterparty-distributed-exchange-need-to" target="_blank" data-bind="locale: 'answer_14'"></a></li>
-                    <li><a href="http://support.counterparty.io/support/solutions/articles/5000003516-how-do-i-get-support-for-counterwallet" target="_blank" data-bind="locale: 'answer_8'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/how-to-read-the-combined-asset-token-currency-pairs-such-as-btcxcp-in-dex/2072" target="_blank" data-bind="locale: 'answer_9'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/when-is-a-dex-order-considered-active-and-how-can-i-cancel-it/1180" target="_blank" data-bind="locale: 'answer_11'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/why-do-i-need-small-amounts-of-bitcoin-to-do-things/1142/1" target="_blank" data-bind="locale: 'answer_12'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/what-is-the-difference-between-miners-fee-and-redeemable-fee/1188" target="_blank" data-bind="locale: 'answer_13'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/what-btc-sellers-on-the-counterparty-distributed-exchange-need-to-know/1183" target="_blank" data-bind="locale: 'answer_14'"></a></li>
+                    <li><a href="https://counterpartytalk.org/t/about-the-counterwallet-support-category/29" target="_blank" data-bind="locale: 'answer_8'"></a></li>
                 </ul>
                 <h5 class="margin-bottom-0">
                   <span data-bind="locale: 'for_other_questions'"></span>
-                  <a href="https://forums.counterparty.io/" target="_blank" data-bind="locale: 'counterparty_forums'"></a>.
+                  <a href="https://counterpartytalk.org/c/support" target="_blank" data-bind="locale: 'counterparty_forums'"></a>.
                 </h5>
                 <h5>
                   <span data-bind="locale: 'for_bugs'"></span> 


### PR DESCRIPTION
... as the original content (that the previous links link to) isn't available, I can't be 100% sure the new links correspond to the old links, but in great majority of cases they should. I created 2 new FAQs for 2 links I wasn't sure what they were supposed to point to.

Also, `http` has been changed to `https`