### PR TITLE
Update balances.html to rename input field "Enter Bitcoin address" to "Enter destination address".

### DIFF
--- a/src/pages/balances.html
+++ b/src/pages/balances.html
@@ -327,7 +327,7 @@
             <label class="control-label col col-sm-3" data-bind="locale: 'send_to'"></label>
             <div class="col col-sm-9">
                 <label class="input"><i class="icon-append fa fa-tag"></i>
-                    <input name="destAddress" data-bind="value: destAddress, valueUpdate: 'input', attr: {placeholder: 'Enter Bitcoin address'}" type="text"/>
+                    <input name="destAddress" data-bind="value: destAddress, valueUpdate: 'input', attr: {placeholder: 'Enter destination address'}" type="text"/>
                 </label>
                 <span class="invalid" data-bind="validationMessage: destAddress"></span>
             </div>


### PR DESCRIPTION
Rename input field "Enter Bitcoin address" to "Enter destination address". This field is also shown when sending other assets than bitcoin. Now also matches Freewallet.