### PR TITLE
Add grunt-cli to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.1",
     "express-http-proxy": "^1.5.1",
     "grunt": "^0.4.1",
+    "grunt-cli": "^0.1.8",
     "grunt-chrome-compile": "0.2.2",
     "grunt-contrib-copy": "0.4.x",
     "grunt-usemin": "2.1.x",


### PR DESCRIPTION
Referring to [README.md on Grunt-cli](https://github.com/gruntjs/grunt-cli/blob/b560cded7cf7c6cf43bfc7f0405bc3cc53581f93/README.md), they wrote "Starting with Grunt v0.4, you should never install Grunt itself globally."