### PR TITLE
Add autocompetion="off" to forms.

### DIFF
--- a/src/pages/exchange.html
+++ b/src/pages/exchange.html
@@ -64,7 +64,8 @@
             <div class="clearfix"></div>
           </header>
           <div> <!-- widget div-->
-            <div class="widget-body min-height-0 no-padding" style="min-height:0 !important" data-bind="validationOptions: { insertMessages: false }"> <!-- widget content -->
+            <form autocomplete="off">
+              <div class="widget-body min-height-0 no-padding" style="min-height:0 !important" data-bind="validationOptions: { insertMessages: false }"> <!-- widget content -->
                 <div class="row" style="height:90px">
                     <section class="col col-lg-4 col-sm-4">
                       <div style="padding:10px">
@@ -96,8 +97,9 @@
                       </div>
                     </section>
                 </div>
-            </div>
-         </div> <!-- end widget div -->
+              </div>
+            </form>
+          </div> <!-- end widget div -->
       </div> <!-- end widget -->
     </article> <!-- WIDGET END -->
 
@@ -283,7 +285,7 @@
         </header>
         <div> <!-- widget div-->
           <div class="widget-body no-padding buyForm"> <!-- widget content -->
-            <form class="form-horizontal">
+            <form class="form-horizontal" autocomplete="off">
               <div class="table-responsive" style="overflow-x:hidden">
                 <table class="table buySellForm">
                   <tbody>
@@ -402,7 +404,7 @@
         </header>
         <div> <!-- widget div-->
           <div class="widget-body no-padding sellForm"> <!-- widget content -->
-            <form class="form-horizontal">
+            <form class="form-horizontal" autocomplete="off">
               <div class="table-responsive" style="overflow-x:hidden">
                 <table class="table buySellForm">
                   <tbody>


### PR DESCRIPTION
This will stop to raise the Chrome password manager.

I'm not sure when was this issue raised.
But at least the latest Chrome raises its password manager like this.

![Screenshot 2020-09-28 at 09 59 23](https://user-images.githubusercontent.com/16408160/94380661-6a393b80-0171-11eb-9dba-94b847e901b9.png)

I found the related topic on  MDN https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
